### PR TITLE
Updated examples/controller.py typo, :s/@/_

### DIFF
--- a/examples/controller.py
+++ b/examples/controller.py
@@ -24,7 +24,7 @@ async def run():
     model = await controller.add_model(
         'libjuju-test',
         'cloud-aws',
-        'cloudcred-aws_tvansteenburgh@external_aws-tim',
+        'cloudcred-aws_tvansteenburgh_external_aws-tim',
     )
     await model.deploy(
         'ubuntu-0',


### PR DESCRIPTION
Possible Typo in the Example/Controller.py

:s/@/_  in the cloud creds

'cloudcred-aws_tvansteenburgh_external_aws-tim',

For LXD I used: 
'cloudcred-localhost_admin_default' 

'cloudcred-localhost_admin@default' fails. 